### PR TITLE
feat: Introduce environment-specific API configuration

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -57,5 +57,6 @@
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="UsePropertyAccessSyntax" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/TrainingSDK/build.gradle.kts
+++ b/TrainingSDK/build.gradle.kts
@@ -41,7 +41,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 groupId = "com.github.cdcountrydelight"
                 artifactId = "TrainingSDK"
-                version = "1.1.0"
+                version = "1.1.1"
                 from(components["release"])
             }
         }

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/data/network/HttpClientManager.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/data/network/HttpClientManager.kt
@@ -19,15 +19,21 @@ internal object HttpClientManager {
     @Volatile
     private var httpClient: HttpClient? = null
 
-    fun getInstance(context: Context, authToken: String): HttpClient {
+    fun getInstance(context: Context, authToken: String, isProdEnv: Boolean): HttpClient {
         return httpClient ?: synchronized(this) {
-            httpClient ?: createHttpClient(context, authToken).also { httpClient = it }
+            httpClient ?: createHttpClient(context, authToken, isProdEnv).also { httpClient = it }
         }
     }
 
-    private fun createHttpClient(context: Context, authToken: String): HttpClient {
+    private fun createHttpClient(
+        context: Context,
+        authToken: String,
+        isProdEnv: Boolean
+    ): HttpClient {
         val engine = OkHttp.create {
-            addInterceptor(getChuckerInterceptor(context))
+            if (!isProdEnv) {
+                addInterceptor(getChuckerInterceptor(context))
+            }
             addInterceptor(LibraryNetworkInterceptorImpl(context))
 
         }
@@ -40,7 +46,7 @@ internal object HttpClientManager {
             }
 
             defaultRequest {
-                url("https://qa-stock.countrydelight.in/api/cd_training/flows/")
+                url(if (isProdEnv) "https://stock.countrydelight.in/api/cd_training/flows/" else "https://qa-stock.countrydelight.in/api/cd_training/flows/")
                 contentType(ContentType.Application.Json)
                 headers {
                     append("Authorization", "Bearer $authToken")

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/data/providers/RepositoryProvider.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/data/providers/RepositoryProvider.kt
@@ -8,7 +8,8 @@ import com.cd.trainingsdk.domain.repository.ITrainingFlowRepository
 
 internal fun getTrainingFlowRepository(
     context: Context,
-    authToken: String
+    authToken: String,
+    isProdEnv: Boolean
 ): ITrainingFlowRepository {
-    return TrainingFlowRepositoryImpl(HttpClientManager.getInstance(context, authToken))
+    return TrainingFlowRepositoryImpl(HttpClientManager.getInstance(context, authToken, isProdEnv))
 }

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/CompleteQnAUseCase.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/CompleteQnAUseCase.kt
@@ -12,8 +12,12 @@ internal class CompleteQnAUseCase {
         context: Context,
         authToken: String,
         flowId: Int,
-        completeQnAContent: List<CompleteQnAContent>
+        completeQnAContent: List<CompleteQnAContent>,
+        isProdEnv: Boolean
     ): DataResponseStatus<CompleteQnaResponseContent> {
-        return getTrainingFlowRepository(context, authToken).completeQnA(flowId, completeQnAContent)
+        return getTrainingFlowRepository(context, authToken, isProdEnv).completeQnA(
+            flowId,
+            completeQnAContent
+        )
     }
 }

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/GetFlowDetailsUseCase.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/GetFlowDetailsUseCase.kt
@@ -10,8 +10,9 @@ internal class GetFlowDetailsUseCase {
     suspend fun invoke(
         context: Context,
         flowId: Int,
-        authToken: String
+        authToken: String,
+        isProdEnv: Boolean
     ): DataResponseStatus<FlowDetailsResponseContent> {
-        return getTrainingFlowRepository(context, authToken).getFlowDetails(flowId)
+        return getTrainingFlowRepository(context, authToken, isProdEnv).getFlowDetails(flowId)
     }
 }

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/GetFlowsListUseCase.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/GetFlowsListUseCase.kt
@@ -10,8 +10,9 @@ internal class GetFlowsListUseCase {
     suspend fun invoke(
         context: Context,
         packageName: String,
-        authToken: String
+        authToken: String,
+        isProdEnv: Boolean
     ): DataResponseStatus<List<FlowListResponseContent>> {
-        return getTrainingFlowRepository(context, authToken).getFlowsList(packageName)
+        return getTrainingFlowRepository(context, authToken, isProdEnv).getFlowsList(packageName)
     }
 }

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/GetQnAUseCase.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/GetQnAUseCase.kt
@@ -10,8 +10,9 @@ internal class GetQnAUseCase {
     suspend fun invoke(
         context: Context,
         authToken: String,
-        flowId: Int
+        flowId: Int,
+        isProdEnv: Boolean
     ): DataResponseStatus<QnaResponseContent> {
-        return getTrainingFlowRepository(context, authToken).getQnADetails(flowId)
+        return getTrainingFlowRepository(context, authToken, isProdEnv).getQnADetails(flowId)
     }
 }

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/TrainingCompletedUseCase.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/domain/use_cases/TrainingCompletedUseCase.kt
@@ -10,8 +10,9 @@ internal class TrainingCompletedUseCase {
     suspend fun invoke(
         context: Context,
         flowId: Int,
-        authToken: String
+        authToken: String,
+        isProdEnv: Boolean
     ): DataResponseStatus<CompleteFlowResponseContent> {
-        return getTrainingFlowRepository(context, authToken).completeTraining(flowId)
+        return getTrainingFlowRepository(context, authToken, isProdEnv).completeTraining(flowId)
     }
 }

--- a/TrainingSDK/src/main/java/com/cd/trainingsdk/presentation/TrainingFlowNavGraph.kt
+++ b/TrainingSDK/src/main/java/com/cd/trainingsdk/presentation/TrainingFlowNavGraph.kt
@@ -23,12 +23,13 @@ fun TrainingFlowNavGraph(
     appName: String = packageName,
     unAuthorizedExceptionCodes: List<Int> = listOf(401),
     navController: NavHostController = rememberNavController(),
+    isProdEnv: Boolean,
     onBackPressed: () -> Unit,
 ) {
 
     val viewModel: TrainingFlowViewModel = viewModel()
     LaunchedEffect(Unit) {
-        viewModel.setUnAuthorizedCodes(unAuthorizedExceptionCodes)
+        viewModel.setUnAuthorizedCodes(unAuthorizedExceptionCodes, isProdEnv)
     }
     NavHost(
         modifier = modifier,

--- a/app/src/main/java/com/cd/trainingapp/MainActivity.kt
+++ b/app/src/main/java/com/cd/trainingapp/MainActivity.kt
@@ -14,9 +14,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             TrainingAppTheme {
                 TrainingFlowNavGraph(
-                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo1NDIxMiwiZXhwIjoxNzYyODQxNjQxLCJpYXQiOjE3NjI3NTUyNDF9.hwOewqUfln6FYCm3HeckXWa3uTDIL_oKEQq0QfobjWU",
+                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo1NDIxMiwiZXhwIjoxNzY0MTgwNzUwLCJpYXQiOjE3NjQwOTQzNTB9.N_f1jeNwgY1kGywTlRbEqPmQqISfZko1r_FRMWlh2Gc",
                     appName = "CD Partner App",
-                    packageName = "deliveryapp.countrydelight.in.deliveryapp"
+                    packageName = "deliveryapp.countrydelight.in.deliveryapp",
+                    isProdEnv = false
                 ) {
 
                 }


### PR DESCRIPTION
This commit introduces the ability to switch between production and non-production (QA) environments for API endpoints and network-level configurations.

A new `isProdEnv: Boolean` flag has been introduced to dynamically configure the base URL and conditionally enable/disable the Chucker network inspector.

**Changes:**

*   **Build & Configuration:**
    *   **SDK Version (`build.gradle.kts`):** Incremented the SDK version from `1.1.0` to `1.1.1`.

*   **Networking (`data/network/HttpClientManager.kt`):**
    *   The `HttpClientManager` now accepts an `isProdEnv: Boolean` flag.
    *   The base URL for API requests is now dynamically set to either the production or QA URL based on this flag.
    *   The Chucker interceptor is now only added to the `HttpClient` when `isProdEnv` is `false`.

*   **SDK Entry Point (`presentation/TrainingFlowNavGraph.kt`):**
    *   The `TrainingFlowNavGraph` composable now requires an `isProdEnv: Boolean` parameter, which is passed down to the `TrainingFlowViewModel`.
    *   The consuming `MainActivity` in the `app` module has been updated to provide this new flag.

*   **ViewModel & Use Cases:**
    *   **`TrainingFlowViewModel.kt`:** A new `isProdEnv` property has been added to store the environment configuration. This flag is now passed through all use case invocations.
    *   **Domain (`domain/use_cases/`):** All use cases (`CompleteQnA`, `GetFlowDetails`, `GetFlowsList`, `GetQnA`, `TrainingCompleted`) now accept and propagate the `isProdEnv` flag to the repository layer.
    *   **Repository Provider (`data/providers/RepositoryProvider.kt`):** The `getTrainingFlowRepository` function now forwards the `isProdEnv` flag to the `HttpClientManager`.